### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -4,6 +4,8 @@
 # For our project, we generate this file through a build process from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/generate-sbom-action/security/code-scanning/4](https://github.com/advanced-security/generate-sbom-action/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions to `contents: read`, which is the minimum required for this workflow. This ensures that the workflow only has read access to the repository contents and cannot perform any write operations.

The `permissions` block will be added immediately after the `name` field (line 6) to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
